### PR TITLE
Add inital draft of MCollective PE upgrader

### DIFF
--- a/files/mco/peupgrade.ddl
+++ b/files/mco/peupgrade.ddl
@@ -1,0 +1,38 @@
+metadata :name        => "peupgrade",
+         :description => "Puppet Enterprise upgrader implemented in MCollective.",
+         :author      => "Ben Ford",
+         :license     => "GPLv2",
+         :version     => "0.0.1",
+         :url         => "http://github.com/binford2k/mco-peupgrade",
+         :timeout     => 30
+
+action "upgrade", :description => "Upgrade Puppet Enterprise to a newer version" do
+   input :version,
+         :prompt      => "Version",
+         :description => "What version should this upgrade to?",
+         :type        => :string,
+         :validation  => '^[0-9]+\.[0-9]+\.[0-9]+$',
+         :optional    => true
+
+   output :msg,
+          :description => "Completion message",
+          :display_as  => "Message"
+end
+
+action "uninstall", :description => "Remove Puppet Enterprise from a node. This does not work from the console." do
+   input :drop,
+         :prompt      => "Drop tables",
+         :description => "Drop all Puppet Enterprise tables from the database",
+         :type        => :boolean,
+         :optional    => true
+
+   input :purge,
+         :prompt      => "Purge config",
+         :description => "Purge configuration files",
+         :type        => :boolean,
+         :optional    => true
+
+   output :msg,
+          :description => "Completion message",
+          :display_as  => "Message"
+end

--- a/files/mco/peupgrade.rb
+++ b/files/mco/peupgrade.rb
@@ -1,0 +1,138 @@
+require 'tmpdir'
+
+module MCollective
+  module Agent
+    class Peupgrade<RPC::Agent
+      metadata :name        => "peupgrade",
+               :description => "Puppet Enterprise upgrader implemented in MCollective.",
+               :author      => "Ben Ford",
+               :license     => "GPLv2",
+               :version     => "0.0.1",
+               :url         => "http://github.com/binford2k/mco-peupgrade",
+               :timeout     => 1800
+
+      action "upgrade" do
+        validate :version, /^[0-9]+\.[0-9]+\.[0-9]+$/
+        version = request[:version]
+        package = package(version)
+        source  = "https://s3.amazonaws.com/pe-builds/released/#{version}/#{package}.tar.gz"
+
+        pid = fork do
+          daemonize!('peupgrade')
+
+          Dir.mktmpdir("peupgrade-") do |dir|
+            system("curl #{source} -o #{File.join(dir, "#{package}.tar.gz")}")
+            system("tar -xzf #{File.join(dir, "#{package}.tar.gz")} -C #{dir}")
+            Dir.chdir(File.join(dir, package))
+            File.open('answers.txt', 'w') { |f| f.write(@answers) }
+            # the output redirection is to catch errors before the installer starts logging
+            system('./puppet-enterprise-upgrader -a answers.txt 2>&1 > peupgrade.lastrun.txt')
+            Dir.glob('*.lastrun.*') { |f| FileUtils.cp(f, '/root') }
+          end
+
+          exit
+        end
+
+        Process.detach(pid)
+        reply[:msg] = "Forked a daemon with PID #{pid} to upgrade Puppet Enterprise to #{package}."
+      end
+
+      action "uninstall" do
+        validate :drop, :boolean
+        validate :purge, :boolean
+
+        # I think it's kind of funny that we have to download the full package to get the uninstaller
+        version = '2.7.2' # hmm, no latest?
+        package = package(version)
+        source  = "https://s3.amazonaws.com/pe-builds/released/#{version}/#{package}.tar.gz"
+
+        opts = ''
+        opts << '-d ' if request[:drop]
+        opts << '-p'  if request[:purge]
+
+        pid = fork do
+          daemonize!('peuninstall')
+
+          Dir.mktmpdir('peupgrade-') do |dir|
+            system("curl #{source} -o #{File.join(dir, "#{package}.tar.gz")}")
+            system("tar -xzf #{File.join(dir, "#{package}.tar.gz")} -C #{dir}")
+            Dir.chdir(File.join(dir, package))
+            # the output redirection is to catch errors before the installer starts logging
+            system("./puppet-enterprise-uninstaller -y #{opts} 2>&1 > peuninstall.lastrun.txt")
+            Dir.glob('*.lastrun.*') { |f| FileUtils.cp(f, '/root') }
+          end
+
+          exit
+        end
+
+        Process.detach(pid)
+        reply[:msg] = "Forked a daemon with PID #{pid} to uninstall Puppet Enterprise."
+      end
+
+      def startup_hook
+        # answers taken from finch's pe_upgrade
+        @answers = "PATH=/usr/local/bin:/opt/puppet/bin:/usr/bin:$PATH
+        q_install=y
+        q_puppet_cloud_install=n
+        q_puppet_enterpriseconsole_install=n
+        q_puppetagent_install=y
+        q_puppetagent_server=`puppet agent --configprint server`
+        q_puppetagent_certname=`puppet agent --configprint certname`
+        q_puppetmaster_install=n
+        q_rubydevelopment_install=n
+        q_upgrade_install_wrapper_modules=n
+        q_upgrade_installation=y
+        q_upgrade_remove_mco_homedir=n
+        q_vendor_packages_install=y
+        q_puppet_symlinks_install=y
+        q_continue_or_reenter_master_hostname=c\n"
+      end
+
+      def daemonize!(name)
+        Process.setsid
+
+        Dir.chdir '/'
+        File.umask 0000
+
+        STDIN.reopen '/dev/null'
+        STDOUT.reopen '/dev/null', 'a'
+        STDERR.reopen '/dev/null', 'a'
+
+        $0 = name
+      end
+
+      def package(version)
+        begin
+          # This is yuk and a half. Do we really not have a better way to do this?
+          # TODO: copy more of finch's logic in here. If these were facts....
+          arch  = Facter.value('architecture')
+          major = Facter.value('operatingsystemrelease').gsub(/\..*$/, '')
+
+          case Facter.value('osfamily')
+          when 'RedHat'
+            os = 'el'
+          when 'Debian'
+            case Facter.value('operatingsystem')
+            when 'Debian'
+              os = 'debian'
+            when 'Ubuntu'
+              os = 'ubuntu'
+            end
+          when 'Suse'
+            os = 'sles'
+          when 'Solaris'
+            os = 'solaris'
+          end
+
+          pkg = "puppet-enterprise-#{version}-#{os}-#{major}-#{arch}"
+        rescue Exception
+          # if anything goes wrong, just use the monolithic package
+          pkg = "puppet-enterprise-#{version}-all"
+        end
+
+        return pkg
+      end
+
+    end
+  end
+end

--- a/manifests/data.pp
+++ b/manifests/data.pp
@@ -103,6 +103,13 @@
 # * global variable: pe_upgrade_logfile
 # * default value: false
 #
+# === [*mco_agent_dir*]
+#
+# If specified, installs the MCollective agent into the specified dir.
+#
+# * global variable: pe_upgrade_mco_agent_dir
+# * default value: '/opt/puppet/libexec/mcollective/mcollective/agent'
+#
 # == Authors
 #
 # Adrien Thebo <adrien@puppetlabs.com>
@@ -162,6 +169,9 @@ class pe_upgrade::data {
 
   if $::pe_upgrade_logfile { $logfile = $::pe_upgrade_logfile }
   else { $logfile = false }
+
+  if $::pe_upgrade_mco_agent_dir { $mco_agent_dir = $::pe_upgrade_mco_agent_dir }
+  else { $mco_agent_dir = '/opt/puppet/libexec/mcollective/mcollective/agent' }
 
   if $::pe_upgrade_migrate_certs { $migrate_certs = $::pe_upgrade_migrate_certs }
   else { $migrate_certs = false }

--- a/manifests/mco_agent.pp
+++ b/manifests/mco_agent.pp
@@ -1,0 +1,63 @@
+# = Class: pe_upgrade::mco_agent
+#
+# This class manages a Puppet Enterprise upgrader implemented in MCollective.
+#
+# == Parameters
+#
+# If a parameter is not specified, it will default to the value in
+# pe_upgrade::data. See that class for values
+#
+# [*mco_agent_dir*]
+#
+# * The directory to install the agent in.
+#
+# This agent currently has two functions:
+#
+# * Upgrade
+#   * Can accept version parameter
+# * Uninstall
+#   * Accepts drop and purge options
+#   * The Enterprise Console doesn't support booleans, so this must be run from the command line
+#
+# Usage
+# =============
+#
+# ### Use Live Management
+#
+# 1. Choose a subset of nodes
+# 2. Click the Advanced Tasks tab
+# 3. Choose the `peupgrade` task
+# 4. Choose the `upgrade` action
+# 5. Optionally provide a version to upgrade to in `x.x.x` format.
+# 6. Click run and go get a coffee.
+#
+# ### Command line example usage
+#
+# * `mco rpc peupgrade upgrade -F fact_is_puppetmaster=false -v`
+# * `mco rpc peupgrade uninstall -F fact_is_puppetmaster=false drop=false purge=false -v`
+#
+# Limitations
+# ============
+#
+# * It is currently not very configurable or robust.
+#
+# Contact
+# =======
+#
+# * Author: Ben Ford
+# * Email: ben.ford@puppetlabs.com
+# * Twitter: @binford2k
+# * IRC (Freenode): binford2k
+#
+class pe_upgrade::mco_agent (
+  $mco_agent_dir = $pe_upgrade::data::mco_agent_dir,
+) {
+  file { "${mco_agent_dir}/peupgrade.rb":
+    ensure => file,
+    source => 'puppet::///modules/pe_upgrade/mco/peupgrade.rb',
+  }
+  file { "${mco_agent_dir}/peupgrade.ddl":
+    ensure => file,
+    source => 'puppet::///modules/pe_upgrade/mco/peupgrade.ddl',
+  }
+}


### PR DESCRIPTION
This only supports upgrading PE to PE, since I couldn't think of a good
way to get the install dir for mco agents on POSS. This can be mitigated
by specifying the `mco_agent_dir` parameter.

This is currently extremely limited and hardly tested, so I don't
recommend merging it just yet, but I'd love to get some love on it.

Note: this will likely never upgrade PE2.x to PE3.x.
