### PR TITLE
Added puppetdb setting to answers file to fix PE install

### DIFF
--- a/templates/answers/default-agent.txt.erb
+++ b/templates/answers/default-agent.txt.erb
@@ -1,6 +1,7 @@
 q_install=y
 q_puppet_cloud_install=n
 q_puppet_enterpriseconsole_install=n
+q_puppetdb_install=n
 q_puppetagent_install=y
 q_puppetagent_server=<%= @server %>
 q_puppetagent_certname=<%= @certname %>


### PR DESCRIPTION
PE install fails with the puppetdb setting missing from the answers file.
