### PR TITLE
Fix distro version resolution for Solaris 10

### DIFF
--- a/lib/facter/pe_upgrade_distro_version.rb
+++ b/lib/facter/pe_upgrade_distro_version.rb
@@ -20,7 +20,7 @@ end
 
 Facter.add(:pe_upgrade_distro_version) do
   confine :operatingsystem => 'Solaris'
-  setcode { Facter.value(:operatingsystemrelease).sub(/\d\.(\d+)/, '\1') }
+  setcode { Facter.value(:kernelrelease).sub(/\d\.(\d+)/, '\1') }
 end
 
 Facter.add(:pe_upgrade_distro_version) do

--- a/spec/unit/pe_upgrade_distro_version_spec.rb
+++ b/spec/unit/pe_upgrade_distro_version_spec.rb
@@ -27,7 +27,25 @@ describe 'pe_upgrade_distro_version fact' do
       '5.3'   => '5.3',
       '6.1'   => '6.1',
       '7.1'   => '7.1',
-    },
+    }
+  }
+
+  distros.each_pair do |distro, tests|
+    tests.each_pair do |testcase, expected|
+      describe "on #{distro} #{testcase}" do
+        before(:each) do
+          stub_fact :operatingsystem, distro
+          stub_fact :operatingsystemrelease, testcase
+        end
+        it { should == expected }
+      end
+    end
+  end
+
+
+  # Solaris is unique - the kernelrelease fact is used instead of
+  # operatingsystemrelease - so this will stub that out.
+  distros = {
     'Solaris' => {
       '5.10'  => '10',
     }
@@ -38,7 +56,7 @@ describe 'pe_upgrade_distro_version fact' do
       describe "on #{distro} #{testcase}" do
         before(:each) do
           stub_fact :operatingsystem, distro
-          stub_fact :operatingsystemrelease, testcase
+          stub_fact :kernelrelease, testcase
         end
         it { should == expected }
       end


### PR DESCRIPTION
Previously, the pe_upgrade_distro_version fact expected to find the
operatingsystemrelease fact in the format of '10.10' for Solaris. This is not
the case:

```
[root@ebstst0app1 ~]# facter -p operatingsystemrelease
operatingsystemrelease => 10_u10
```

Because of this, the regex doesn't match correctly and sets the
pe_upgrade_distro_version fact as '10_u10' instead of '10'. This commit
updates the regex to look for the underscore and select the first '10' instead
of looking for a period.
